### PR TITLE
Provide rooter also from the symbols exported by IDA

### DIFF
--- a/plugins/bap/utils/run.py
+++ b/plugins/bap/utils/run.py
@@ -91,7 +91,7 @@ def run_bap_with(argument_string):
     command = (
         "\
         \"{bap_executable_path}\" \"{input_file_path}\" \
-        --read-symbols-from=\"{symbol_file_location}\" --symbolizer=file \
+        --read-symbols-from=\"{symbol_file_location}\" --symbols=file \
         {remaining_args} \
         -d > \"{bap_output_file}\" 2>&1 \
         ".format(**args)


### PR DESCRIPTION
Since we are already providing latest symbols to symbolizer from IDA, we can also pass the same symbols along to the rooter. This PR does this.

From `bap --help`:

```
   --symbols=NAME
       Use NAME as rooter and symbolizer. This is a shortcut for
       --rooter=NAME --symbolizer=NAME. [...]
```
