### PR TITLE
Colorize ANSI escaped parts of lines

### DIFF
--- a/plugins/bap/plugins/bap_view.py
+++ b/plugins/bap/plugins/bap_view.py
@@ -40,10 +40,13 @@ class BAP_View(idaapi.plugin_t):
         """Display BAP View to the user."""
         v = cls._get_view()
         if v is not None:
+            import re
+            ansi_escape = re.compile(r'\x1b[^m]*m([^\x1b]*)\x1b[^m]*m')
+            recolorize = lambda s : ansi_escape.sub('\1\x22\\1\2\x22', s)
             v.ClearLines()
             with open(cls._get_store_path(), 'r') as f:
                 for line in f.read().split('\n'):
-                    v.AddLine(line)
+                    v.AddLine(recolorize(line))
             v.Refresh()  # Ensure latest information gets to the screen
             v.Show()  # Actually show it on the screen
 


### PR DESCRIPTION
Earlier, if IDA received an ANSI color sequence escaped line, then the output in BAP View would mess up on that line. With this PR, that part of the line is colorized differently, thereby giving the user the highlighted information.

As for the regex used, it is a simple `\x1b[^m]*m([^\x1b]*)\x1b[^m]*m` 
![regex](https://cloud.githubusercontent.com/assets/5683582/16243434/3ea57544-37c5-11e6-9bbb-47192355abf1.png)

The line it replaces the regex to is a special format IDA uses for colorizing things, which looks like this:
![colorized output](https://cloud.githubusercontent.com/assets/5683582/16243481/7023f1cc-37c5-11e6-9d49-9a5c3c8b356c.png)
