### PR TITLE
Brancher

### DIFF
--- a/plugins/bap/utils/ida.py
+++ b/plugins/bap/utils/ida.py
@@ -113,11 +113,13 @@ def dump_brancher_info(output_filename):
         return list(CodeRefsFrom(ea, True))
 
     with open(output_filename, 'w+') as out:
+        out.write('(\n')
         for ea in all_valid_ea():
             if is_branch_insn(ea):
                 out.write("(0x%x (%s))\n" % (
                     ea,
                     (' '.join(map(lambda d: '0x%x' % d, branch_list(ea))))))
+        out.write(')\n')
 
 
 def add_hotkey(hotkey, func):

--- a/plugins/bap/utils/ida.py
+++ b/plugins/bap/utils/ida.py
@@ -99,6 +99,27 @@ def dump_symbol_info(output_filename):
                     GetFunctionAttr(f, FUNCATTR_END)))
 
 
+def dump_brancher_info(output_filename):
+    """Dump information for BAP's brancher into output_filename."""
+    from idautils import CodeRefsFrom
+    import idc
+
+    idaapi.autoWait()
+
+    def is_branch_insn(ea):
+        return len(list(CodeRefsFrom(ea, False))) > 0
+
+    def branch_list(ea):
+        return list(CodeRefsFrom(ea, True))
+
+    with open(output_filename, 'w+') as out:
+        for ea in all_valid_ea():
+            if is_branch_insn(ea):
+                out.write("(0x%x (%s))\n" % (
+                    ea,
+                    (' '.join(map(lambda d: '0x%x' % d, branch_list(ea))))))
+
+
 def add_hotkey(hotkey, func):
     """
     Assign hotkey to run func.


### PR DESCRIPTION
This PR causes IDA to dump information for BAP's brancher to use.
It outputs all the locations from where the flow of control is not "normal flow" (i.e. goes to the next address instruction).
### Output format

```
(
(addr1 (dest1 dest2 dest3 ...))
(addr2 ( ... ))
...
)
```
### Example output

```
(
(0x10 (0x14 0x1c))
(0x28 (0x2c 0x14))
(0x44 (0x48 0x60))
(0x48 (0x14))
(0x5c (0x60 0x14))
(0x68 (0x6c 0x4c))
(0x70 (0x14))
(0x84 (0x88 0xc8))
(0x9c (0xa0 0xb4))
(0xa0 (0xc8))
(0xb0 (0xb4 0xc8))
<......truncated......>
)
```
