### PR TITLE
Brancher v2.0

### DIFF
--- a/plugins/bap/utils/ida.py
+++ b/plugins/bap/utils/ida.py
@@ -120,7 +120,7 @@ def dump_brancher_info(output_filename):
     def is_jump_insn(ea):  # Only unconditional branches
         return len(branch(ea)) == len(dest(ea)) == 1
 
-    def labelled(addrs, label):
+    def labeled(addrs, label):
         l = lambda d: '(0x%x %s)' % (d, label)
         return ' '.join(map(l, addrs))
 
@@ -130,12 +130,12 @@ def dump_brancher_info(output_filename):
             if is_jump_insn(ea):
                 out.write('(0x%x (%s))\n' % (
                     ea,
-                    labelled(dest(ea), 'Jump')))
+                    labeled(dest(ea), 'Jump')))
             elif is_branch_insn(ea):
                 out.write('(0x%x (%s %s))\n' % (
                     ea,
-                    labelled(branch(ea), 'Cond'),
-                    labelled(fall(ea), 'Fall')))
+                    labeled(branch(ea), 'Cond'),
+                    labeled(fall(ea), 'Fall')))
             else:
                 pass  # Normal instruction, uninteresting
         out.write(')\n')

--- a/plugins/bap/utils/ida.py
+++ b/plugins/bap/utils/ida.py
@@ -106,10 +106,10 @@ def dump_brancher_info(output_filename):
     idaapi.autoWait()
 
     def dest(ea):
-        return list(CodeRefsFrom(ea, True))
+        return list(CodeRefsFrom(ea, flow=True))
 
     def branch(ea):
-        return list(CodeRefsFrom(ea, False))
+        return list(CodeRefsFrom(ea, flow=False))
 
     def fall(ea):
         return list(set(dest(ea)) - set(branch(ea)))


### PR DESCRIPTION
This PR basically adds meta data to each destination in the output, classifying it as either
- `Cond`
- `Fall`
- `Jump`

This basically allows us to easily import into bap's IDA Brancher.

Output sample:

```
(
(0x158 ((0x19680 Cond) (0x15c Fall)))
(0x164 ((0x19680 Jump)))
...
)
```

Note: One major advantage this gives: IDA resolves a lot of indirect jumps as well, which weren't resolved via bap's other branchers, so basically, we can now even understand "switch case" type of statements :)
