### PR TITLE
Get Function info from BAP to augment IDA

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ interoperatibility between BAP and IDA Pro. It also provides many useful feature
 Features
 --------
 
+### Function information augmentation
+
+By just hitting the `Shift+P` key, IDA will call BAP which will use its own analysis (and all the information sources that it knows of) to obtain all the locations where there are functions. This information is then propagated to IDA and used to create functions there automatically. This is especially useful in scenarios where there are a lot of indirect calls etc and BAP (using its different plugins) is able to detect functions in the code which IDA is unable to do so.
+
 ### Taint Propagation
 
 By choosing a taint source and hitting either `Ctrl+A` (for tainting register) or `Ctrl+Shift+A` (for tainting pointer), one can easily see how taint propagates through the code, in both disassembly and decompilation views.

--- a/plugins/bap/plugins/bap_functions.py
+++ b/plugins/bap/plugins/bap_functions.py
@@ -1,0 +1,77 @@
+"""
+IDA Python Plugin to get information about functions from BAP into IDA.
+
+Finds all the locations in the executable that BAP knows to be functions and
+marks them as such in IDA.
+
+Keybindings:
+    Shift-P : Run BAP and mark code as functions in IDA
+"""
+import idautils
+
+
+class BAP_Functions(idaapi.plugin_t):
+    """Plugin to get functions from BAP and mark them in IDA."""
+
+    @classmethod
+    def mark_functions(cls):
+        """Run BAP, get functions, and mark them in IDA."""
+        import tempfile
+        from bap.utils.run import run_bap_with
+
+        idc.SetStatus(IDA_STATUS_WAITING)
+        idaapi.refresh_idaview_anyway()
+
+        args = {
+            'symbol_file': tempfile.mkstemp(suffix='.symout',
+                                                prefix='ida-bap-')[1],
+        }
+
+        run_bap_with(
+            "\
+            --print-symbol-format=addr \
+            --dump=symbols:\"{symbol_file}\" \
+            ".format(**args), no_extras=True
+        )
+
+        with open(args['symbol_file'], 'r') as f:
+            for line in f:
+                line = line.strip()
+                if len(line) == 0:
+                    continue
+                addr = int(line, 16)
+                end_addr = idaapi.BADADDR  # Lets IDA decide the end
+                idaapi.add_func(addr, end_addr)
+        
+        idc.SetStatus(IDA_STATUS_READY)
+
+        idc.Refresh()  # Force the updated information to show up
+
+    flags = idaapi.PLUGIN_FIX
+    comment = "BAP Functions Plugin"
+    help = "BAP Functions Plugin"
+    wanted_name = "BAP Functions Plugin"
+    wanted_hotkey = ""
+
+    def init(self):
+        """Initialize Plugin."""
+        from bap.utils.ida import add_hotkey
+        add_hotkey("Shift-P", self.mark_functions)
+        return idaapi.PLUGIN_KEEP
+
+    def term(self):
+        """Terminate Plugin."""
+        pass
+
+    def run(self, arg):
+        """
+        Run Plugin.
+
+        Ignored since keybindings are installed.
+        """
+        pass
+
+
+def PLUGIN_ENTRY():
+    """Install BAP_Functions upon entry."""
+    return BAP_Functions()


### PR DESCRIPTION
This PR does a bunch of things:
- Updates `run_bap_with` to accept an optional parameter that disables all the automatic extras that we normally run
- Adds the `BAP_Functions` IDA Python plugin which allows us to find all the locations in the executable that BAP knows to be functions and mark them as such in IDA.
- Update the README with the new feature
### Keybindings

`Shift-P` - Run BAP and mark functions in IDA
