### PR TITLE
use only IDA as rooter

### DIFF
--- a/plugins/bap/utils/run.py
+++ b/plugins/bap/utils/run.py
@@ -133,7 +133,9 @@ def run_bap_with(argument_string, no_extras=False):
         command = (
             "\
             \"{bap_executable_path}\" \"{input_file_path}\" \
-            --read-symbols-from=\"{symbol_file_location}\" --symbolizer=file \
+            --read-symbols-from=\"{symbol_file_location}\" \
+            --symbolizer=file \
+            --rooter=file \
             {remaining_args} \
             -d > \"{bap_output_file}\" 2>&1 \
             ".format(**args)


### PR DESCRIPTION
This will give a more consistent results, as the abstraction that is
visible from IDA will be much closer to an abstraction that is used
by BAP.

This will not affect bap_functions plugin, as it uses `no_extras` flag,
that ignores options that regards symbols.
