### PR TITLE
fixes and enhances function recover plugin

### DIFF
--- a/plugins/bap/utils/run.py
+++ b/plugins/bap/utils/run.py
@@ -23,14 +23,24 @@ class Bap(object):
 
     We will try to keep it clean from IDA
     specifics, so that later we can lift it to the bap-python library
+
+    Attributes:
+
+       DEBUG   print executed commands and keep temporary files
+       args    default arguments, inserted after `bap <input>`
+       plugins a list of available plugins
     """
 
     DEBUG = False
 
+    args = []
+
+    plugins = []
+
     def __init__(self, bap, input_file):
         """Sandbox for the BAP process.
 
-        Each process is sandboxed, so that all intermediated data is
+        Each process is sandboxed, so that all intermediate data are
         stored in a temporary directory.
 
         instance variables:
@@ -50,7 +60,7 @@ class Bap(object):
 
         """
         self.tmpdir = tempfile.mkdtemp(prefix="bap")
-        self.args = [bap, input_file]
+        self.args = [bap, input_file] + self.args
         self.proc = None
         self.fds = []
         self.out = self.tmpfile("out")
@@ -59,6 +69,9 @@ class Bap(object):
         self.env = {'BAP_LOG_DIR': self.tmpdir}
         if self.DEBUG:
             self.env['BAP_DEBUG'] = 'yes'
+        if not Bap.plugins:
+            with os.popen(bap + ' --list-plugins') as out:
+                Bap.plugins = [e.split()[1] for e in out]
 
     def run(self):
         "starts BAP process"


### PR DESCRIPTION
The function recovery plugin was broken for some amount of time, as we
passed symbol file to bap, effectively disabling BAP own function
finding capabilities, so bap always returned the same amount of function
starts.

This commit also enhances the recovery plugin, by lowering the recovery
threshold. Although it will lead to more false positives it is
acceptable since IDA will ignore function starts that occur in a body of
an discovered function, that was already discovered and
disassembled. Since most of the functions have their bodies after
starts, we added sorting of the addresses, so that function starts are
added to the system in the ascending order.

This commit also adds two new attributes to the BapIda class. The first
one is called [args] and is a list of default arguments, shared by all
instances. It is useful to adapt the behavior of the plugins to your
needs, and to perform fast prototyping and debugging.

The second attribute is called [plugins] and it contains a list of
available BAP plugins. This is useful, when an IDA plugin needs to adapt
its behavior based on the presence of particular BAP plugins. For
example, the function start identification plugin, is allowed to tackle
with the byteweight parameters only if it is installed.