### PR TITLE
Propagate taint with primus

### DIFF
--- a/plugins/bap/plugins/bap_taint.py
+++ b/plugins/bap/plugins/bap_taint.py
@@ -55,6 +55,8 @@ class PropagateTaint(BapIda):
 
         if self.ENGINE == 'primus':
             self.args += [
+                '--run-entry-points=all-subroutines',
+                '--primus-limit-max-length=100',
                 '--primus-propagate-taint-run',
                 '--primus-promiscuous-mode',
                 '--primus-greedy-scheduler'

--- a/plugins/bap/plugins/bap_taint.py
+++ b/plugins/bap/plugins/bap_taint.py
@@ -27,15 +27,18 @@ patterns = [
     ('taints', 'yellow')
 ]
 
-
 class PropagateTaint(BapIda):
+    ENGINE='primus'
+
     "Propagate taint information using BAP"
     def __init__(self, addr, kind):
         super(PropagateTaint,self).__init__()
+
         self.action = 'taint propagating from {:s}0x{:X}'.format(
             '*' if kind == 'ptr' else '',
             addr)
-        self.passes = ['taint','propagate-taint','map-terms','emit-ida-script']
+        propagate = 'run' if self.ENGINE == 'primus' else 'propagate-taint'
+        self.passes = ['taint', propagate, 'map-terms','emit-ida-script']
         self.script = self.tmpfile('py')
         scheme = self.tmpfile('scm')
         for (pat,color) in patterns:
@@ -50,6 +53,12 @@ class PropagateTaint(BapIda):
             '--emit-ida-script-file', self.script.name
         ]
 
+        if self.ENGINE == 'primus':
+            self.args += [
+                '--primus-propagate-taint-run',
+                '--primus-promiscuous-mode',
+                '--primus-greedy-scheduler'
+            ]
 
 
 class BapTaint(idaapi.plugin_t):


### PR DESCRIPTION
Adds an option to choose a taint propagation engine. Since it is for the experts, there is no GUI for that. Just use the python console:

```python
PropagateTaint.ENGINE=primus # to choose Primus
PropagateTaint.ENGINE=legacy # to use the legacy framework (default)
```