### PR TITLE
updates to BAP 1.4 release

### DIFF
--- a/plugins/bap/plugins/__init__.py
+++ b/plugins/bap/plugins/__init__.py
@@ -1,4 +1,4 @@
 """This module contains all the plugins that will be loaded by BAP-Loader."""
 
-__all__ = ('bap_bir_attr', 'bap_taint', 'bap_view', 'pseudocode_bap_comment',
+__all__ = ('bap_bir_attr', 'bap_taint_ptr', 'bap_taint_reg' 'bap_view', 'pseudocode_bap_comment',
            'pseudocode_bap_taint')

--- a/plugins/bap/plugins/bap_bir_attr.py
+++ b/plugins/bap/plugins/bap_bir_attr.py
@@ -73,7 +73,10 @@ class BapBirAttr(idaapi.plugin_t):
         """
 
         args_msg = "Arguments that will be passed to `bap'"
-
+        # If a user is not fast enough in providing the answer
+        # IDA Python will popup a modal window that will block
+        # a user from providing the answer.
+        idaapi.disable_script_timeout()
         args = idaapi.askstr(ARGS_HISTORY, '--passes=', args_msg)
         if args is None:
             return

--- a/plugins/bap/plugins/bap_taint_ptr.py
+++ b/plugins/bap/plugins/bap_taint_ptr.py
@@ -1,4 +1,4 @@
-from bap.plugins.bap_taint import BapTaint
+from bap.utils.bap_taint import BapTaint
 
 class BapTaintPtr(BapTaint):
     wanted_hotkey = "Ctrl-Shift-A"

--- a/plugins/bap/plugins/bap_taint_reg.py
+++ b/plugins/bap/plugins/bap_taint_reg.py
@@ -1,4 +1,4 @@
-from bap.plugins.bap_taint import BapTaint
+from bap.utils.bap_taint import BapTaint
 
 class BapTaintReg(BapTaint):
     wanted_hotkey = "Shift-A"

--- a/plugins/bap/plugins/pseudocode_bap_taint.py
+++ b/plugins/bap/plugins/pseudocode_bap_taint.py
@@ -8,7 +8,7 @@ import idc
 import idaapi
 
 from bap.utils import hexrays
-from bap.plugins.bap_taint import BapTaint
+from bap.utils.bap_taint import BapTaint
 
 colors = {
     'black':   0x000000,

--- a/plugins/bap/utils/__init__.py
+++ b/plugins/bap/utils/__init__.py
@@ -1,4 +1,4 @@
 """Commonly used utilities."""
 
 __all__ = ('sexpr', 'bap_comment', 'run', 'ida', 'abstract_ida_plugins',
-           'config')
+           'config', 'bap_taint')

--- a/plugins/plugin_loader_bap.py
+++ b/plugins/plugin_loader_bap.py
@@ -1,6 +1,7 @@
 """Loads all possible BAP IDA Python plugins."""
-
-
+import os
+import bap.plugins
+import bap.utils.run
 import idaapi
 
 
@@ -15,24 +16,22 @@ class bap_loader(idaapi.plugin_t):
 
     def init(self):
         """Read directory and load as many plugins as possible."""
-        import os
-        import bap.plugins
-        import bap.utils.run
-        import idaapi
+        self.plugins = []
 
         idaapi.msg("BAP Loader activated\n")
 
         bap.utils.run.check_and_configure_bap()
 
         plugin_path = os.path.dirname(bap.plugins.__file__)
-        idaapi.msg("Loading plugins from {}\n".format(plugin_path))
+        idaapi.msg("BAP> Loading plugins from {}\n".format(plugin_path))
 
         for plugin in sorted(os.listdir(plugin_path)):
             path = os.path.join(plugin_path, plugin)
             if not plugin.endswith('.py') or plugin.startswith('__'):
                 continue  # Skip non-plugins
-            idaapi.load_plugin(path)
-        return idaapi.PLUGIN_SKIP  # The loader will be called whenever needed
+            idc.Message('BAP> Loading {}\n'.format(plugin))
+            self.plugins.append(idaapi.load_plugin(path))
+        return idaapi.PLUGIN_KEEP
 
     def term(self):
         """Ignored."""


### PR DESCRIPTION
In this update we are relying on the new Primus Taint Analysis
Framework to provide us data-flow information via the
`primus-propagate-taint` compatibility layer. We allow a user to
select the taint propagation engine, as well as its parameters.

This commit also moves the bap_taint module to the utilities package,
as otherwise it is loaded multiple times by each plugin separatly that
may lead to unexpected results (don't ask me what are they)

There is also a small fix that prevents the racing condition between
askXXX dialogs and IDA Python breakability facility.

The merge of this PR is blocked until
https://github.com/BinaryAnalysisPlatform/bap/pull/784 is merged