### PR TITLE
Add IDA Pro brancher.

### DIFF
--- a/plugins/bap/utils/ida.py
+++ b/plugins/bap/utils/ida.py
@@ -86,11 +86,12 @@ def output_types(out):
 @service.provider('brancher')
 def output_branches(out):
     """Dump static successors for each instruction """
+    out.write('(')
     for addr in addresses():
         succs = Succs(addr)
-        if succs.jmps:
+        if succs.jmps or (succs.fall is not None):
             out.write('{}\n'.format(succs.dumps()))
-
+    out.write(')')
 
 def set_color(addr, color):
     idc.SetColor(addr, idc.CIC_ITEM, color)
@@ -137,7 +138,7 @@ class Succs(object):
         return ''.join([
             '({:#x} '.format(self.addr),
             ' ({:#x}) '.format(self.fall) if self.fall else '()',
-            '{})'.format(sexps(self.dests))
+            '{})'.format(sexps(self.jmps))
         ])
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27,py24,py3
+envlist=py27,py3
 
 [testenv]
 deps=pytest


### PR DESCRIPTION
These changes are complementary to [IDA Pro brancher. #868](https://github.com/BinaryAnalysisPlatform/bap/pull/868)  in the bap repository, which allow a user to specify the argument '--brancher=ida' to ask BAP to utilize IDA's brancher information.