### PR TITLE
fixes loader  IDA-7 compatibility

### DIFF
--- a/plugins/bap/utils/ida.py
+++ b/plugins/bap/utils/ida.py
@@ -1,6 +1,8 @@
 """Utilities that interact with IDA."""
 import idaapi
 import idc
+from idaapi import *
+from idc import *
 import idautils
 
 from ._service import Service
@@ -30,7 +32,7 @@ def output_segments(out):
     out.writelines(('(', info.get_proc_name()[1], ' ', size, ' ('))
     for seg in idautils.Segments():
         out.write("\n({} {} {:d} ({:#x} {:d}))".format(
-            idaapi.get_segm_name(seg),
+            get_segm_name(seg),
             "code" if idaapi.segtype(seg) == idaapi.SEG_CODE else "data",
             idaapi.get_fileregion_offset(seg),
             seg, idaapi.getseg(seg).size()))

--- a/plugins/bap/utils/ida.py
+++ b/plugins/bap/utils/ida.py
@@ -1,14 +1,16 @@
 """Utilities that interact with IDA."""
 import idaapi
 import idc
-from idaapi import *
-from idc import *
 import idautils
 
 from ._service import Service
 from ._comment_handler import CommentHandlers
 from ._ctyperewriter import Rewriter
 
+try:
+    from idc import get_segm_name
+except ImportError:
+    from idaapi import get_segm_name
 
 service = Service()
 comment = CommentHandlers()

--- a/tests/mockidaapi.py
+++ b/tests/mockidaapi.py
@@ -6,12 +6,12 @@ ASKBTN_CANCEL = NotImplemented
 PLUGIN_DRAW = NotImplemented
 PLUGIN_HIDE = NotImplemented
 PLUGIN_KEEP = NotImplemented
-class plugin_t(object): NotImplemented
-class text_sink_t(object): NotImplemented
-class Choose2(object): NotImplemented
-def idadir(sub): NotImplemented
-def get_cmt(ea, off): NotImplemented
-def set_cmt(ea, off): NotImplemented
-def askyn_c(dflt, title): NotImplemented
-def get_input_file_path() : NotImplemented
-def get_segm_name(ea): NotImplemented
+class plugin_t(object): pass
+class text_sink_t(object): pass
+class Choose2(object): pass
+def idadir(sub): return NotImplemented
+def get_cmt(ea, off): return NotImplemented
+def set_cmt(ea, off): return NotImplemented
+def askyn_c(dflt, title): return NotImplemented
+def get_input_file_path() : return NotImplemented
+def get_segm_name(ea): return NotImplemented

--- a/tests/mockidaapi.py
+++ b/tests/mockidaapi.py
@@ -14,3 +14,4 @@ def get_cmt(ea, off): NotImplemented
 def set_cmt(ea, off): NotImplemented
 def askyn_c(dflt, title): NotImplemented
 def get_input_file_path() : NotImplemented
+def get_segm_name(ea): NotImplemented


### PR DESCRIPTION
This PR fixes a bug in loader script due to compatibility with IDA-7 version.

The core of the problem is in `get_segm_name` function, which exists both in `6.9`  and `7.1` versions, but was shadowed with some other implementation in the latter one. 